### PR TITLE
HanasuAI Version 2.0.0

### DIFF
--- a/config/example_channelconfig.json
+++ b/config/example_channelconfig.json
@@ -3,6 +3,7 @@
 		"autotranslate":false,
 		"ignoreduser":[],
 		"defaultLanguage" : "ISO 639-3 language code!",
-		"bannedWords" : []
+		"bannedWords" : [],
+		"autouser" : []
 	}
 }

--- a/config/example_config.js
+++ b/config/example_config.js
@@ -40,6 +40,18 @@ const defaultChannelConfig = {
 //It's for validating the user input for the !defaultlanguage command
 const supportedLanguages = ['eng','jpn']; 
 
+
+// mapping for the language codes
+// commandName is the command the user used. This is the key for the mapping
+// the value is the language code for the deepl API
+const languageMappings = {
+	'jp': 'JA',
+	'en': 'EN-US',
+	'円': 'EN-US',
+	'es': 'ES',
+	'fr': 'FR'
+};
+
 function loadChannelConfig() {
 	try {
 		const data = fs.readFileSync(ChannelConfigFile, 'utf8');
@@ -67,4 +79,4 @@ function saveChannelConfig(channelconfig) {
 	}
 }
 
-module.exports = {tmiconf, DeeplConfig, Botowner, StatisticsFile, AutoTranslateIgnoredUserGlobal, saveChannelConfig, loadChannelConfig,defaultChannelConfig,supportedLanguages};
+module.exports = {tmiconf, DeeplConfig, Botowner, StatisticsFile, AutoTranslateIgnoredUserGlobal, saveChannelConfig, loadChannelConfig, defaultChannelConfig, supportedLanguages, languageMappings};

--- a/config/example_config.js
+++ b/config/example_config.js
@@ -33,7 +33,8 @@ const defaultChannelConfig = {
 	autotranslate: false,
 	ignoreduser: [],
 	defaultLanguage: "jpn",
-	bannedWords: []
+	bannedWords: [],
+	autouser : []
 }
 
 //THIS IS FIXED IN THE CODE!! Only change this if you know what you are doing!!

--- a/hanasuAI.js
+++ b/hanasuAI.js
@@ -78,8 +78,6 @@ function handelAutoTranslate(msg, target, recipient, channelname)
 
 	Translator.translateToChat(target, recipient, msg, targetLanguage);
 	Stats.incrementCounter(target.substring(1), targetLanguage);
-
-	return;
 }
 
 function botownerCommand(command, target, channelname)
@@ -143,7 +141,7 @@ function botownerCommand(command, target, channelname)
 
 function broadcasterCommand(command, target, autotranslate, channelname)
 {
-	if(command.commandName === 'automode' && command.hasParameter)
+	if(command.commandName === 'automode' && command.hasParameter) //enable or disable auto translation for the channel
 	{
 		if(command.inputtext === 'off')
 		{ 	if(autotranslate)
@@ -172,7 +170,7 @@ function broadcasterCommand(command, target, autotranslate, channelname)
 		}
 		return;
 	}	
-	else if(command.commandName === 'defaultlanguage' && command.hasParameter)
+	else if(command.commandName === 'defaultlanguage' && command.hasParameter) //change the default language for the channel
 	{
 		if(config.supportedLanguages.includes(command.inputtext))
 		{
@@ -196,7 +194,7 @@ function modCommand(command, target, channelname)
 		client.say(target,`Hey, I am still here. Running since ${uptime}!`);	
 		return;		
 	}	
-	else if(command.commandName === 'ignoreuser' && command.hasParameter)
+	else if(command.commandName === 'ignoreuser' && command.hasParameter) //add or remove a user from the ignorelist
 	{
 		const userToIgnore = getUsernameFromInput(command.inputtext);
 
@@ -224,7 +222,7 @@ function modCommand(command, target, channelname)
 		config.saveChannelConfig(channelconfig);
 		return;
 	}
-	else if(command.commandName === "banword" && command.hasParameter)
+	else if(command.commandName === "banword" && command.hasParameter) //add or remove a word from the banned words list
 	{
 		const bannedWords = channelconfig[channelname].bannedWords;
 		const index = bannedWords.indexOf(command.inputtext);
@@ -244,7 +242,7 @@ function modCommand(command, target, channelname)
 		config.saveChannelConfig(channelconfig);
 		return;
 	}
-	else if(command.commandName === "autouser" && command.hasParameter)
+	else if(command.commandName === "autouser" && command.hasParameter) //add or remove a user from the auto translate list
 	{
 		const autoTranslateUser = getUsernameFromInput(command.inputtext);
 
@@ -413,8 +411,7 @@ function onMessageHandler (target, user, msg, self)
 	//check if user is allowed to use HanasuAI or not.
 	const blockedUser = channelconfig[channelname].ignoreduser.includes(user.username);	
 	if(blockedUser)
-		return;
-	
+		return;	
 
 	// Create a new ChatMessage object
 	const chatMessage = new ChatMessage(msg, commandPrefixes);
@@ -448,10 +445,9 @@ function onMessageHandler (target, user, msg, self)
 		}
 
 		//Used to check if a user is a mod or not
-		let isMod = user.mod || user['user-type'] === 'mod';
-		let isBroadcaster = target.slice(1) === user.username; //check if user broadcaster by comparing current channel with the username of the sender
-		let isModUp = isMod || isBroadcaster;
-		let isBotOwner = user.username === config.Botowner; //twitch username of the botowner	
+		const isBotOwner = user.username === config.Botowner; //twitch username of the botowner	
+		const isBroadcaster = target.slice(1) === user.username || isBotOwner; //check if user broadcaster by comparing current channel with the username of the sender
+		const isMod = user.mod || user['user-type'] === 'mod'|| isBroadcaster || isBotOwner; //check if user is a mod
 	
 		//commands only the Botowner can execute
 		if(isBotOwner)
@@ -459,12 +455,12 @@ function onMessageHandler (target, user, msg, self)
 			botownerCommand(command, target, channelname);
 		}
 		//commands streamer + botowner
-		if(isBroadcaster || isBotOwner)
+		if(isBroadcaster)
 		{
 			broadcasterCommand(command, target, autoTranslateChannel, channelname);
 		}
 		//commands mods and owner can execute
-		if(isModUp || isBotOwner)
+		if(isMod)
 		{
 			modCommand(command, target, channelname);
 		}

--- a/hanasuAI.js
+++ b/hanasuAI.js
@@ -343,19 +343,8 @@ function userCommand(command, target, autotranslate)
 
 function translateCommand(command, target)
 {
-	//mapping for the language codes
-	// command.commandName is the command the user used. This is the key for the mapping
-	// the value is the language code for the deepl API
-	const languageMappings = {
-		'jp': 'JA',
-		'en': 'EN-US',
-		'円': 'EN-US',
-		'es': 'ES',
-		'fr': 'FR'
-	};
-
 	//get the language code for the command
-	const targetLanguage = languageMappings[command.commandName];
+	const targetLanguage = config.languageMappings[command.commandName];
 
 	if (targetLanguage && command.hasParameter) //translate the message to the target language
 	{

--- a/hanasuAI.js
+++ b/hanasuAI.js
@@ -18,6 +18,7 @@ const tmi = require('tmi.js');
 const proc = require('process');
 const Translator = require('./modules/translator.js');
 const Stats = require('./modules/stats.js');
+const ChatMessage = require('./modules/chatmessage.js');
 //some ugly hackery stuff to get the import working.. idk a better way yet.
 var franc
 (async () => {
@@ -39,453 +40,288 @@ Translator.setClient(client);
 Translator.setAPIConfig(config.DeeplConfig);
 Translator.setBotowner(config.Botowner);
 
-// Valid commands start with !
-const commandPrefix = '!'; //！
-const jpcommandPrefix = '！';
+const commandPrefixes = ['!', '！']; //command prefixes for the bot
 
-// Called every time a message comes in. Handler for all commands
-function onMessageHandler (target, user, msg, self) {
-	if (self) // Ignore messages from the bot
-	 return;  
-	 
-	 //target.substring because the target channel has a leading #. So we remove that.
-	 const channelname = target.substring(1);
-	 
-	 //ignore messages HanasuAI gets via PM because the user isn't in config
-	if(!channelconfig.hasOwnProperty(channelname))
+function handelAutoTranslate(msg, target, recipient, channelname)
+{
+	//ignore empty messages.
+	if(!msg.replace(/\s/g, '').length)
+		return;		
+	
+	//temporarily replace all non english user.
+	//If a user was tagged in the message (user starting with @) and the name was written in Japanese Character like @こんばんは, HanasuAI thought the whole Message
+	//was japanese and tryed to translate this into english. Eventho the message was english in the first pace.
+	//It's only temp because Deepl handels Proper noun quite good. No need to remove them completly
+	//This Regex matches an @ at the beginning of a word followed by 1 to many non-word character like a-z A-Z or 0-9. The last \B ends the word.
+	let msgWithoutLocalNames = msg.replace(/\B@\W+\B/g, "")
+	
+	//detect the language that was used in the message
+	const detectLang = franc(msgWithoutLocalNames, { minLength: 5 });
+	const defaultLanguage = channelconfig[channelname].defaultLanguage;
+	
+	//language Mapping.
+	// If the default language is eng and the detected language is eng as well -> translate to Japanes. If not -> english
+	//mapping if the following formalt:  ISO 639-3 ? deepl language code : deepl language code
+	//as franc uses ISO 639-3 and deepl has it's own language codes
+	const languageMappings = {
+		eng: { targetLanguage: detectLang === "eng" ? "JA" : "EN-US" },
+		jpn: { targetLanguage: detectLang === "jpn" ? "EN-US" : "JA" },
+	};
+	
+	const { targetLanguage } = languageMappings[defaultLanguage];
+	
+	//check if the english message has at least 5 character.
+	//This way I can ignore most messages like "hehe" "xD" or something like this. No need to translate them.
+	//This also makes sure that messages only containing unicode, so emojis only messages will not translated.
+	if(detectLang !== "jpn" && !/[A-Za-z ]{5,}/.test(msg))
 		return;
 
-	//check if user is allowed to use HanasuAI or not.
-	const blockedUser = channelconfig[channelname].ignoreduser.includes(user.username);
+	Translator.translateToChat(target, recipient, msg, targetLanguage);
+	Stats.incrementCounter(target.substring(1), targetLanguage);
 
-	//check if autotranslation is enabled for target channel 
-	const autoTranslateChannel = channelconfig[channelname].autotranslate;
+	return;
+}
 
-	//check if auto translation is enabled for a user
-	const autoTranslateUser = channelconfig[channelname].autouser.includes(user.username);
-
-	const autotranslate = autoTranslateChannel || autoTranslateUser;
-
-	//remove emotes from message, because they can mess up the translation. (Thanks to stefanjudis for this idea/example code on how to handle emotes)
-	//This also prevents the bot from trying to translate messages, that are filled with emotes only.
-	//"user" includes all meta informations about the user, that sends the message. It also includes informations about the used emotes! Example emote [id, positions]: "425618": ["0-2"]
-	if(user.emotes) 
+function botownerCommand(command, target, channelname)
+{
+	if(command.commandName === 'shutdown') //shutdown the bot
 	{
-		//array to save all emotes that needs to be deleted later.
-		let emotesToDelete=[];
-		//iterate of emotes to find all positions 
-		//using sequential loop to get all emotes.
-		for(const positions of Object.values(user.emotes))
-		{
-			const position = positions[0]; //We only need the first position for every emote, as we can relpace all emotes of this kind
-			const [start, end] = position.split("-");
-			//using match(/./gu) to get unicode emojis as one character. Twitch sees these at 1 character. JS String not.
-			//with this, I put all characters in an array, so the start and end positions are correct again.
-			emotesToDelete.push(msg.match(/./gu).slice(parseInt(start),parseInt(end)+1).join(''));		
-		}
-
-		//replace all emotes with an empty string
-		//using sequential loop to get all emotes. 
-		for(emote of emotesToDelete){			
-			//NodeJS doesn't know replaceAll. So we need to use Regex. 	
-			//escape special character as some of them are used in emotes like ":)" or ":("	
-			msg = msg.replace(new RegExp(emote.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'), 'g'),'');
-		};
+		client.say(target,"Byebye o/");			
+		proc.exit();			
 	}
-
-	//remove URL and e-mail addresses from the message. 
-	//Regex for URL and E-Mail addresses
-	const urlRegex = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[.\!\/\\w]*))?)/
-	msg = msg.replace(urlRegex,"");
-
-	//remove banned words from the message
-	const bannedWords = channelconfig[channelname].bannedWords;
-	const bannedWordRegex = new RegExp(`\\b(${bannedWords.join('|')})\\b`, 'gi');
-	//replace all banned words with nothing
-	msg = msg.replace( bannedWordRegex, '');
-	//remove all the extra spaces 
-	msg = msg.replace(/\s+/g, ' ').trim();
-
-	//If someone hits reply in the chat, the chat will automaticly add the targeted user as first word, starting with an @
-	//If this is the case, remove the first word to check if the user used a command while using the reply feature.
-	//this has to be after the emote section. If not, the position of the emotes would be wrong, because the original message has already been edited
-	let recipient = null;
-	if(msg.substr(0,1) === '@')
-    {
-		recipient = msg.substr(0, msg.indexOf(" "));
-        msg = msg.substr(msg.indexOf(" ") + 1);
-    }
-
-	//If no command Prefix: handle autotranslation if enabled.
-	if (msg.substr(0, 1) !== commandPrefix && msg.substr(0,1) !== jpcommandPrefix)  
+	else if(command.commandName === 'api') //sends the API usage of the month in chat
 	{
-		//ignore empty messages.
-		if(!msg.replace(/\s/g, '').length)
-			return;
-
-		//check if autotranslate is enabled
-		if(!autotranslate)
-			return;
-		
-		//check if user is on ignorelist 
-		if(config.AutoTranslateIgnoredUserGlobal.includes(user.username) || blockedUser)
-			return;
-
-		//temporarily replace all non english user.
-		//If a user was tagged in the message (user starting with @) and the name was written in Japanese Character like @こんばんは, HanasuAI thought the whole Message
-		//was japanese and tryed to translate this into english. Eventho the message was english in the first pace.
-		//It's only temp because Deepl handels Proper noun quite good. No need to remove them completly
-		//This Regex matches an @ at the beginning of a word followed by 1 to many non-word character like a-z A-Z or 0-9. The last \B ends the word.
-		let msgWithoutLocalNames = msg.replace(/\B@\W+\B/g, "")
-
-		//detect the language that was used in the message
-		const detectLang = franc(msgWithoutLocalNames, { minLength: 5 });
-		const defaultLanguage = channelconfig[channelname].defaultLanguage;
-
-		//language Mapping.
-		// If the default language is eng and the detected language is eng as well -> translate to Japanes. If not -> english
-		//mapping if the following formalt:  ISO 639-3 ? deepl language code : deepl language code
-		//as franc uses ISO 639-3 and deepl has it's own language codes
-		const languageMappings = {
-			eng: { targetLanguage: detectLang === "eng" ? "JA" : "EN-US" },
-			jpn: { targetLanguage: detectLang === "jpn" ? "EN-US" : "JA" },
-		};
-
-		const { targetLanguage } = languageMappings[defaultLanguage];
-
-		//check if the english message has at least 5 character.
-		//This way I can ignore most messages like "hehe" "xD" or something like this. No need to translate them.
-		//This also makes sure that messages only containing unicode, so emojis only messages will not translated.
-		if(detectLang !== "jpn" && !/[A-Za-z ]{5,}/.test(msg))
-			return;
-
-		Translator.translateToChat(target, recipient, msg, targetLanguage);
-		Stats.incrementCounter(target.substring(1), targetLanguage);
-
+		Translator.sendAPIUsageToChat(target);
+		return;
+	}		
+	else if(command.commandName === 'broadcast' && command.hasParameter) //sends a message to all channels
+	{
+		for(channel of config.tmiconf.channels)	
+			client.say(channel,command.inputtext);
 		return;
 	}
-
-	let commandName, inputtext, hasParameter
-	//used to check if the user send parameter
-	if(msg.indexOf(" ")<0)
+	else if(command.commandName === "joinchannel" && command.hasParameter) //adds the bot to some twitch channel
 	{
-		commandName = msg.slice(1).toLowerCase();
-		hasParameter = false;
+		const userToJoin = getUsernameFromInput(command.inputtext); //no need for null check as client.join should go into catch.
+		client.join(userToJoin).then((data) => {
+			
+			const channelname = data[0].substring(1);
+			channelconfig[channelname] = {...config.defaultChannelConfig}; //add default config to new entry
+
+			config.saveChannelConfig(channelconfig); //save new config file.
+
+			Stats.addChannelToStatsData(channelname); //add user to stats system.
+
+			client.say(target, `Joined channel ${data[0]}!`);
+			logger.log( `Joined channel ${data[0]}!`);
+		}).catch((err) => 
+		{
+			client.say(target,`Could not join channel ${userToJoin}. Please check logs.`);
+			logger.log(`ERROR joining channel ${userToRemove}: ${err}`);
+		});
+		return;
 	}
-	else
+	else if(command.commandName === "removechannel" && command.hasParameter) //removes the bot from a twitchchannel
 	{
-		// The command name is the first substring one and remove the !:
-		commandName = msg.substr(0, msg.indexOf(" ")).slice(1).toLowerCase();
-		//The message that should be translated and remove the first space 
-		inputtext = msg.substr(msg.indexOf(" ")).slice(1);
-		//prevent command injection!
-		if(inputtext.substr(0,1) === '!' || inputtext.substr(0,1) === '/')
+		const userToRemove = getUsernameFromInput(command.inputtext); //no need for null check as client.join should go into catch.
+		client.part(userToRemove).then((data) => 
 		{
-			logger.log(`INFO: Command injection found! ${user.username} tryed to use ${inputtext}!`);
-			return;
-		}
-		hasParameter = true;
+			const channelname = data[0].substring(1);
+			delete channelconfig[channelname]; //remove entry from config.
+
+			config.saveChannelConfig(channelconfig); //save new file
+			client.say(target, `I left from channel ${data[0]}!`);
+			logger.log( `Disconnected from channel ${data[0]}!`);
+		}).catch((err) => 
+		{
+			client.say(target,`Could not disconnect from channel ${userToRemove}. Please check logs.`);
+			logger.log(`ERROR disconnecting from channel ${userToRemove}: ${err}`);
+		});
+		return;
 	}
-	//Used to check if a user is a mod or not
-	let isMod = user.mod || user['user-type'] === 'mod';
-	let isBroadcaster = target.slice(1) === user.username; //check if user broadcaster by comparing current channel with the username of the sender
-	let isModUp = isMod || isBroadcaster;
+}
 
-	let isBotOwner = user.username === config.Botowner; //twitch username of the botowner	
-
-	//commands only the Botowner can execute
-	if(isBotOwner)
+function broadcasterCommand(command, target, autotranslate, channelname)
+{
+	if(command.commandName === 'automode' && command.hasParameter)
 	{
-		if(commandName === 'shutdown') //shutdown the bot
-		{
-			client.say(target,"Byebye o/");			
-			proc.exit();			
-		}
-		else if(commandName === 'api') //sends the API usage of the month in chat
-		{
-			Translator.sendAPIUsageToChat(target);
-			return;
-		}		
-		else if(commandName === 'broadcast' && hasParameter) //sends a message to all channels
-		{
-			for(channel of config.tmiconf.channels)	
-				client.say(channel,inputtext);
-			return;
-		}
-		else if(commandName === "joinchannel" && hasParameter) //adds the bot to some twitch channel
-		{
-			const userToJoin = getUsernameFromInput(inputtext); //no need for null check as client.join should go into catch.
-			client.join(userToJoin).then((data) => {
-				
-				const channelname = data[0].substring(1);
-				channelconfig[channelname] = {...config.defaultChannelConfig}; //add default config to new entry
-
-				config.saveChannelConfig(channelconfig); //save new config file.
-
-				Stats.addChannelToStatsData(channelname); //add user to stats system.
-
-				client.say(target, `Joined channel ${data[0]}!`);
-				logger.log( `Joined channel ${data[0]}!`);
-			}).catch((err) => 
+		if(command.inputtext === 'off')
+		{ 	if(autotranslate)
 			{
-				client.say(target,`Could not join channel ${userToJoin}. Please check logs.`);
-				logger.log(`ERROR joining channel ${userToRemove}: ${err}`);
-			});
-			return;
-		}
-		else if(commandName === "removechannel" && hasParameter) //removes the bot from a twitchchannel
-		{
-			const userToRemove = getUsernameFromInput(inputtext); //no need for null check as client.join should go into catch.
-			client.part(userToRemove).then((data) => 
-			{
-				const channelname = data[0].substring(1);
-				delete channelconfig[channelname]; //remove entry from config.
-
-				config.saveChannelConfig(channelconfig); //save new file
-				client.say(target, `I left from channel ${data[0]}!`);
-				logger.log( `Disconnected from channel ${data[0]}!`);
-			}).catch((err) => 
-			{
-				client.say(target,`Could not disconnect from channel ${userToRemove}. Please check logs.`);
-				logger.log(`ERROR disconnecting from channel ${userToRemove}: ${err}`);
-			});
-			return;
-		}
-	}
-	//commands streamer + botowner
-	if(isBroadcaster || isBotOwner)
-	{
-		if(commandName === 'automode' && hasParameter)
-		{
-			if(inputtext === 'off')
-			{ 	if(autotranslate)
-				{
-					channelconfig[channelname].autotranslate = false;	
-					config.saveChannelConfig(channelconfig);			
-					client.say(target,"Disabled auto-translation! | オートトランスレーションの無効化");
-					logger.log("AUTOMODE INFO: Disabled auto-translation for " + target);
-				}
-				else
-					client.say(target,"Auto-translation is already disabled. | 自動翻訳がすでに無効になっている");
-
+				channelconfig[channelname].autotranslate = false;	
+				config.saveChannelConfig(channelconfig);			
+				client.say(target,"Disabled auto-translation! | オートトランスレーションの無効化");
+				logger.log("AUTOMODE INFO: Disabled auto-translation for " + target);
 			}
-			else if (inputtext === 'on')
-			{
-				if(!autotranslate) //to avoid double activation
-				{
-					channelconfig[channelname].autotranslate = true;
-					config.saveChannelConfig(channelconfig);
-					client.say(target,"Enabled auto-translation! | オートトランスレーションを有効にしました");
-					logger.log("AUTOMODE INFO: Enabled auto-translation for " + target);
-				}
-				else
-					client.say(target,"Auto-translation is already enabled. | 自動翻訳がすでに起動している");
+			else
+				client.say(target,"Auto-translation is already disabled. | 自動翻訳がすでに無効になっている");
 
-			}
-			return;
-		}	
-		else if(commandName === 'defaultlanguage' && hasParameter)
+		}
+		else if (command.inputtext === 'on')
 		{
-			if(config.supportedLanguages.includes(inputtext))
+			if(!autotranslate) //to avoid double activation
 			{
-				client.say(target,`Changed default language to ${inputtext}`);
-				channelconfig[channelname].defaultLanguage = inputtext;
+				channelconfig[channelname].autotranslate = true;
 				config.saveChannelConfig(channelconfig);
+				client.say(target,"Enabled auto-translation! | オートトランスレーションを有効にしました");
+				logger.log("AUTOMODE INFO: Enabled auto-translation for " + target);
 			}
 			else
-				client.say("Please provide a default language. (eng, jpn)");
+				client.say(target,"Auto-translation is already enabled. | 自動翻訳がすでに起動している");
 
-			return;
 		}
-	}
-	//commands mods and owner can execute
-	if(isModUp || isBotOwner)
+		return;
+	}	
+	else if(command.commandName === 'defaultlanguage' && command.hasParameter)
 	{
-		if(commandName === 'hanasu') //ping command to check if the bot is sill running + uptime
+		if(config.supportedLanguages.includes(command.inputtext))
 		{
-			var time = process.uptime();
-			var uptime = (time + "").toHHMMSS();
-			client.say(target,`Hey, I am still here. Running since ${uptime}!`);	
-			return;		
-		}	
-		else if(commandName === 'ignoreuser' && hasParameter)
-		{
-			const userToIgnore = getUsernameFromInput(inputtext);
-
-			if(!userToIgnore)
-			{
-				client.say(target,"Please provide a valid twitch username. (Not a displayname!)");
-				return;
-			}
-			const ignoredUsers = channelconfig[channelname].ignoreduser;
-			const index = ignoredUsers.indexOf(userToIgnore);
-
-			if(index !== -1)
-			{
-				// Remove user from the ignoreduser array using splice
-				ignoredUsers.splice(index, 1);
-				client.say(target, `Removed user ${userToIgnore} from the ignorelist.`);
-				logger.log(`Removed user ${userToIgnore} from the ignore list for ${target}`);
-			}
-			else
-			{
-				ignoredUsers.push(userToIgnore);
-				client.say(target, `Added user ${userToIgnore} to the ignorelist.`);
-				logger.log(`Added user ${userToIgnore} to the ignore list for ${target}`);
-			}
+			client.say(target,`Changed default language to ${command.inputtext}`);
+			channelconfig[channelname].defaultLanguage = command.inputtext;
 			config.saveChannelConfig(channelconfig);
+		}
+		else
+			client.say("Please provide a default language. (eng, jpn)");
+
+		return;
+	}
+}
+
+function modCommand(command, target, channelname)
+{
+	if(command.commandName === 'hanasu') //ping command to check if the bot is sill running + uptime
+	{
+		var time = process.uptime();
+		var uptime = (time + "").toHHMMSS();
+		client.say(target,`Hey, I am still here. Running since ${uptime}!`);	
+		return;		
+	}	
+	else if(command.commandName === 'ignoreuser' && command.hasParameter)
+	{
+		const userToIgnore = getUsernameFromInput(command.inputtext);
+
+		if(!userToIgnore)
+		{
+			client.say(target,"Please provide a valid twitch username. (Not a displayname!)");
 			return;
 		}
-		else if(commandName === "banword" && hasParameter)
-		{
-			const bannedWords = channelconfig[channelname].bannedWords;
-			const index = bannedWords.indexOf(inputtext);
+		const ignoredUsers = channelconfig[channelname].ignoreduser;
+		const index = ignoredUsers.indexOf(userToIgnore);
 
-			if(index !== -1)
-			{
-				bannedWords.splice(index, 1);
-				client.say(target, `Removed "${inputtext}" from the banned words list.`);
-				logger.log(`Removed ${inputtext} from the banned word list for ${target}`);
-			}
-			else
-			{
-				bannedWords.push(inputtext);
-				client.say(target, `Added "${inputtext}" to the banned words list.`);
-				logger.log(`Added ${inputtext} to the banned word list for ${target}`);
-			}
-			config.saveChannelConfig(channelconfig);
+		if(index !== -1)
+		{
+			// Remove user from the ignoreduser array using splice
+			ignoredUsers.splice(index, 1);
+			client.say(target, `Removed user ${userToIgnore} from the ignorelist.`);
+			logger.log(`Removed user ${userToIgnore} from the ignore list for ${target}`);
+		}
+		else
+		{
+			ignoredUsers.push(userToIgnore);
+			client.say(target, `Added user ${userToIgnore} to the ignorelist.`);
+			logger.log(`Added user ${userToIgnore} to the ignore list for ${target}`);
+		}
+		config.saveChannelConfig(channelconfig);
+		return;
+	}
+	else if(command.commandName === "banword" && command.hasParameter)
+	{
+		const bannedWords = channelconfig[channelname].bannedWords;
+		const index = bannedWords.indexOf(command.inputtext);
+
+		if(index !== -1)
+		{
+			bannedWords.splice(index, 1);
+			client.say(target, `Removed "${command.inputtext}" from the banned words list.`);
+			logger.log(`Removed ${command.inputtext} from the banned word list for ${target}`);
+		}
+		else
+		{
+			bannedWords.push(command.inputtext);
+			client.say(target, `Added "${command.inputtext}" to the banned words list.`);
+			logger.log(`Added ${command.inputtext} to the banned word list for ${target}`);
+		}
+		config.saveChannelConfig(channelconfig);
+		return;
+	}
+	else if(command.commandName === "autouser" && command.hasParameter)
+	{
+		const autoTranslateUser = getUsernameFromInput(command.inputtext);
+
+		if(!autoTranslateUser)
+		{
+			client.say(target,"Please provide a valid twitch username. (Not a displayname!)");
 			return;
 		}
-		else if(commandName === "autouser" && hasParameter)
+
+		const autotranslateUserList = channelconfig[channelname].autouser;
+		const index = autotranslateUserList.indexOf(autoTranslateUser);
+
+		if(index !== -1)
 		{
-			const autoTranslateUser = getUsernameFromInput(inputtext);
-
-			if(!autoTranslateUser)
-			{
-				client.say(target,"Please provide a valid twitch username. (Not a displayname!)");
-				return;
-			}
-
-			const autotranslateUserList = channelconfig[channelname].autouser;
-			const index = autotranslateUserList.indexOf(autoTranslateUser);
-
-			if(index !== -1)
-			{
-				// Remove user from the ignoreduser array using splice
-				autotranslateUserList.splice(index, 1);
-				client.say(target, `Removed user ${autoTranslateUser} from the auto translation.`);
-				logger.log(`Removed user ${autoTranslateUser} from the auto translate list for ${target}`);
-			}
-			else
-			{
-				autotranslateUserList.push(autoTranslateUser);
-				client.say(target, `Added user ${autoTranslateUser} to the auto translation list.`);
-				logger.log(`Added user ${autoTranslateUser} to the auto translation list for ${target}`);
-			}
-			config.saveChannelConfig(channelconfig);
-			return;
+			// Remove user from the ignoreduser array using splice
+			autotranslateUserList.splice(index, 1);
+			client.say(target, `Removed user ${autoTranslateUser} from the auto translation.`);
+			logger.log(`Removed user ${autoTranslateUser} from the auto translate list for ${target}`);
 		}
-	}
-	// User commands	
-	if (commandName === 'jp' && hasParameter && !blockedUser) 
-	{
-		try 
+		else
 		{
-			Translator.translateToChat(target,recipient, inputtext,'JA');
-			Stats.incrementCounter(target.substring(1),'JA');			
-		} catch (error) 
-		{
-			logger.error('Error translating this message to Japanese: ' + inputtext);
-			logger.error(error);
+			autotranslateUserList.push(autoTranslateUser);
+			client.say(target, `Added user ${autoTranslateUser} to the auto translation list.`);
+			logger.log(`Added user ${autoTranslateUser} to the auto translation list for ${target}`);
 		}
-
+		config.saveChannelConfig(channelconfig);
 		return;
 	}
-	else if((commandName === 'en' || commandName === '円') && hasParameter && !blockedUser)
-	{		
-		try 
-		{
-			Translator.translateToChat(target,recipient,inputtext,'EN-US');
-			Stats.incrementCounter(target.substring(1),'EN-US');			
-		} catch (error) 
-		{
-			logger.error('Error translating this message to English: ' + inputtext);
-			logger.error(error);			
-		}
+}
 
-		return;
-	}
-	else if (commandName === 'es' && hasParameter && !blockedUser) 
-	{
-		try 
-		{
-			Translator.translateToChat(target,recipient,inputtext,'ES');		
-		} catch (error) 
-		{
-			logger.error('Error translating this message to Spanish: ' + inputtext);
-			logger.error(error);
-		}
-
-		return;
-	}
-	else if (commandName === 'fr' && hasParameter && !blockedUser) 
-	{
-		try 
-		{
-			Translator.translateToChat(target,recipient,inputtext,'FR');		
-		} catch (error) 
-		{
-			logger.error('Error translating this message to French: ' + inputtext);
-			logger.error(error);
-		}
-
-		return;
-	}
-	else if(commandName === 'infoen')
+function userCommand(command, target, autotranslate)
+{
+	if(command.commandName === 'infoen')
 	{
 		let infoMsg = "Hey, my name is HanasuAI. I can translate messages for you! ";
 		if(!autotranslate)
 			infoMsg = infoMsg + "Just type !jp for Japanese translation or !en for English translation. I will automatically detect your input language.";
 		else
 			infoMsg = infoMsg + "Currently I'm running in auto-translate mode.";
-		if(recipient)
-			infoMsg = recipient + " " + infoMsg;
-		else if(hasParameter)
-			infoMsg = inputtext + " " + infoMsg;
+		if(command.recipient)
+			infoMsg = command.recipient + " " + infoMsg;
+		else if(command.hasParameter)
+			infoMsg = command.inputtext + " " + infoMsg;
 
 		client.say(target, infoMsg);
 		return;
 	}
-	else if (commandName === 'infojp')
+	else if (command.commandName === 'infojp')
 	{
 		let infoMsg = "やあ！私の名前は HanasuAI (話すエーアイ)です。";						
 		if(!autotranslate)
 			infoMsg = infoMsg + "あなたのためにメッセージを翻訳することができます。日本語の翻訳には「!jp」、英語の翻訳には「!en」と入力してください。入力された言語を自動的に検出します。";		
 		else
 			infoMsg = infoMsg + "現在、自動翻訳モードで動作しています。";	
-		if(recipient)
-			infoMsg = recipient + " " + infoMsg;
-		else if(hasParameter)
-			infoMsg = inputtext + " " + infoMsg;
+		if(command.recipient)
+			infoMsg = command.recipient + " " + infoMsg;
+		else if(command.hasParameter)
+			infoMsg = command.inputtext + " " + infoMsg;
 
 		client.say(target, infoMsg);
 		return;
 	}
-	else if(commandName === 'stats')
+	else if(command.commandName === 'stats')
 	{		
 		Stats.getChannelStats(target.substring(1), channelstats => {
 			client.say(target, `This month I translated ${channelstats.toJP}x to Japanese 🇯🇵 and ${channelstats.toEN} times to English 🇺🇸 for ${target.substring(1)}.`);
 		});
 		return;
 	}
-	else if (commandName === 'jstats')
+	else if (command.commandName === 'jstats')
 	{
 		Stats.getChannelStats(target.substring(1), channelstats => {
 			client.say(target, `今月は、${target.substring(1)} の日本語🇯🇵に${channelstats.toJP}回、英語🇺🇸に${channelstats.toEN}回翻訳しました。`);
 		});
 		return;
 	}
-	else if(commandName === 'statsg')
+	else if(command.commandName === 'statsg')
 	{
 		Stats.getStatsGlobal((month, total) => {
 			client.say(target, `This month I translated ${month.toJP}x into Japanese 🇯🇵 and ${month.toEN}x into English 🇺🇸. `+ 
@@ -493,7 +329,7 @@ function onMessageHandler (target, user, msg, self) {
 		});
 		return;
 	}
-	else if(commandName === 'jstatsg')
+	else if(command.commandName === 'jstatsg')
 	{
 		Stats.getStatsGlobal((month, total) => {
 			client.say(target, `今月は、${month.toJP}xを日本語🇯🇵に、${month.toEN}xを英語🇺🇸に翻訳しました。 `+ 
@@ -501,6 +337,152 @@ function onMessageHandler (target, user, msg, self) {
 		});
 		return;
 	}
+}
+
+function translateCommand(command, target)
+{
+	if (command.commandName === 'jp' && command.hasParameter) 
+	{
+		try 
+		{
+			Translator.translateToChat(target, command.recipient, command.inputtext,'JA');
+			Stats.incrementCounter(target.substring(1),'JA');			
+		} catch (error) 
+		{
+			logger.error('Error translating this message to Japanese: ' + command.inputtext);
+			logger.error(error);
+		}
+
+		return;
+	}
+	else if((command.commandName === 'en' || command.commandName === '円') && command.hasParameter)
+	{		
+		try 
+		{
+			Translator.translateToChat(target, command.recipient, command.inputtext,'EN-US');
+			Stats.incrementCounter(target.substring(1),'EN-US');			
+		} catch (error) 
+		{
+			logger.error('Error translating this message to English: ' + command.inputtext);
+			logger.error(error);			
+		}
+
+		return;
+	}
+	else if (command.commandName === 'es' && command.hasParameter) 
+	{
+		try 
+		{
+			Translator.translateToChat(target, command.recipient, command.inputtext,'ES');		
+		} catch (error) 
+		{
+			logger.error('Error translating this message to Spanish: ' + command.inputtext);
+			logger.error(error);
+		}
+
+		return;
+	}
+	else if (command.commandName === 'fr' && command.hasParameter ) 
+	{
+		try 
+		{
+			Translator.translateToChat(target, command.recipient, command.inputtext,'FR');		
+		} catch (error) 
+		{
+			logger.error('Error translating this message to French: ' + command.inputtext);
+			logger.error(error);
+		}
+
+		return;
+	}
+}
+
+// Called every time a message comes in. Handler for all commands
+function onMessageHandler (target, user, msg, self) 
+{
+	if (self) // Ignore messages from the bot
+	 return;  
+	 
+	 //target.substring because the target channel has a leading #. So we remove that.
+	 const channelname = target.substring(1);
+	 
+	 //ignore messages HanasuAI gets via PM because the user isn't in config
+	 if(!channelconfig.hasOwnProperty(channelname))
+	 return;
+	
+	//check if user is allowed to use HanasuAI or not.
+	const blockedUser = channelconfig[channelname].ignoreduser.includes(user.username);	
+	if(blockedUser)
+		return;
+	
+
+	// Create a new ChatMessage object
+	const chatMessage = new ChatMessage(msg, commandPrefixes);
+
+	//"user" includes all meta informations about the user, that sends the message. It also includes the emotes used.
+	chatMessage.removeEmotes(user.emotes);
+	
+	chatMessage.cleanMessage(channelconfig[channelname]?.bannedWords || []); //remove URLs and banned words from the message
+	
+	//If someone hits reply in the chat, the chat will automaticly add the targeted user as first word, starting with an @
+	//If this is the case, remove the first word to check if the user used a command while using the reply feature.
+	//this has to be after the emote section. If not, the position of the emotes would be wrong, because the original message has already been edited
+	let recipient = chatMessage.getRecipient();
+
+	//check if autotranslation is enabled for target channel 
+	const autoTranslateChannel = channelconfig[channelname].autotranslate;		
+	//check if auto translation is enabled for a user
+	const autoTranslateUser = channelconfig[channelname].autouser.includes(user.username);		
+	const canAutoTranslate = autoTranslateChannel || autoTranslateUser;
+
+	//If no command Prefix: handle autotranslation if enabled.
+	if (chatMessage.isCommand())  
+	{
+		const command = chatMessage.createCommand();
+
+		//prevent command injection!	
+		if(['!', '/'].includes(command.inputtext.charAt(0)))
+		{
+			logger.log(`INFO: Command injection found! ${username} tryed to use ${command.inputtext}!`);
+			return;			
+		}
+
+		//Used to check if a user is a mod or not
+		let isMod = user.mod || user['user-type'] === 'mod';
+		let isBroadcaster = target.slice(1) === user.username; //check if user broadcaster by comparing current channel with the username of the sender
+		let isModUp = isMod || isBroadcaster;
+		let isBotOwner = user.username === config.Botowner; //twitch username of the botowner	
+	
+		//commands only the Botowner can execute
+		if(isBotOwner)
+		{
+			botownerCommand(command, target, channelname);
+		}
+		//commands streamer + botowner
+		if(isBroadcaster || isBotOwner)
+		{
+			broadcasterCommand(command, target, autoTranslateChannel, channelname);
+		}
+		//commands mods and owner can execute
+		if(isModUp || isBotOwner)
+		{
+			modCommand(command, target, channelname);
+		}
+		// User commands	
+		userCommand(command, target, autoTranslateChannel);
+		translateCommand(command, target);		
+	}	
+	else
+	{
+		if(!canAutoTranslate)
+			return;
+
+		//check if user is on ignorelist 
+		if(config.AutoTranslateIgnoredUserGlobal.includes(user.username))
+			return;
+	
+		handelAutoTranslate(msg, target, recipient, channelname);		
+	}	
 }
 
 //function for formating time.

--- a/hanasuAI.js
+++ b/hanasuAI.js
@@ -42,6 +42,7 @@ Translator.setBotowner(config.Botowner);
 
 const commandPrefixes = ['!', '！']; //command prefixes for the bot
 
+//function to handle auto translation
 function handelAutoTranslate(msg, target, recipient, channelname)
 {
 	//ignore empty messages.
@@ -80,6 +81,7 @@ function handelAutoTranslate(msg, target, recipient, channelname)
 	Stats.incrementCounter(target.substring(1), targetLanguage);
 }
 
+//function to handle botowner commands
 function botownerCommand(command, target, channelname)
 {
 	if(command.commandName === 'shutdown') //shutdown the bot
@@ -139,6 +141,7 @@ function botownerCommand(command, target, channelname)
 	}
 }
 
+//function to handle broadcaster commands
 function broadcasterCommand(command, target, autotranslate, channelname)
 {
 	if(command.commandName === 'automode' && command.hasParameter) //enable or disable auto translation for the channel
@@ -185,6 +188,7 @@ function broadcasterCommand(command, target, autotranslate, channelname)
 	}
 }
 
+//function to handle mod commands
 function modCommand(command, target, channelname)
 {
 	if(command.commandName === 'hanasu') //ping command to check if the bot is sill running + uptime

--- a/hanasuAI.js
+++ b/hanasuAI.js
@@ -59,7 +59,12 @@ function onMessageHandler (target, user, msg, self) {
 	const blockedUser = channelconfig[channelname].ignoreduser.includes(user.username);
 
 	//check if autotranslation is enabled for target channel 
-	const autotranslate = channelconfig[channelname].autotranslate;
+	const autoTranslateChannel = channelconfig[channelname].autotranslate;
+
+	//check if auto translation is enabled for a user
+	const autoTranslateUser = channelconfig[channelname].autouser.includes(user.username);
+
+	const autotranslate = autoTranslateChannel || autoTranslateUser;
 
 	//remove emotes from message, because they can mess up the translation. (Thanks to stefanjudis for this idea/example code on how to handle emotes)
 	//This also prevents the bot from trying to translate messages, that are filled with emotes only.
@@ -331,7 +336,7 @@ function onMessageHandler (target, user, msg, self) {
 			config.saveChannelConfig(channelconfig);
 			return;
 		}
-		else if(commandName == "banword" && hasParameter)
+		else if(commandName === "banword" && hasParameter)
 		{
 			const bannedWords = channelconfig[channelname].bannedWords;
 			const index = bannedWords.indexOf(inputtext);
@@ -347,6 +352,35 @@ function onMessageHandler (target, user, msg, self) {
 				bannedWords.push(inputtext);
 				client.say(target, `Added "${inputtext}" to the banned words list.`);
 				logger.log(`Added ${inputtext} to the banned word list for ${target}`);
+			}
+			config.saveChannelConfig(channelconfig);
+			return;
+		}
+		else if(commandName === "autouser" && hasParameter)
+		{
+			const autoTranslateUser = getUsernameFromInput(inputtext);
+
+			if(!autoTranslateUser)
+			{
+				client.say(target,"Please provide a valid twitch username. (Not a displayname!)");
+				return;
+			}
+
+			const autotranslateUserList = channelconfig[channelname].autouser;
+			const index = autotranslateUserList.indexOf(autoTranslateUser);
+
+			if(index !== -1)
+			{
+				// Remove user from the ignoreduser array using splice
+				autotranslateUserList.splice(index, 1);
+				client.say(target, `Removed user ${autoTranslateUser} from the auto translation.`);
+				logger.log(`Removed user ${autoTranslateUser} from the auto translate list for ${target}`);
+			}
+			else
+			{
+				autotranslateUserList.push(autoTranslateUser);
+				client.say(target, `Added user ${autoTranslateUser} to the auto translation list.`);
+				logger.log(`Added user ${autoTranslateUser} to the auto translation list for ${target}`);
 			}
 			config.saveChannelConfig(channelconfig);
 			return;

--- a/modules/chatmessage.js
+++ b/modules/chatmessage.js
@@ -1,9 +1,11 @@
 class ChatMessage {
 
 	#message;
+	#commandPrefixes;
 
-	constructor(message) {
+	constructor(message, commandPrefixes) {
 		this.#message = message;
+		this.#commandPrefixes = commandPrefixes;
 	}
 
 	getMessage() 
@@ -65,7 +67,54 @@ class ChatMessage {
 			this.#message = this.#message.replace(new RegExp(emote.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'), 'g'),'');
 		};
 	}
+
+	getRecipient() 
+	{
+		let recipient = null;
+		const tagIndex = this.#message.indexOf('@');
+
+		if(tagIndex === 0)
+		{
+			const firstSpaceIndex = this.#message.indexOf(' ');
+			recipient = firstSpaceIndex !== -1 ? this.#message.substring(tagIndex, firstSpaceIndex) : this.#message;
+			this.#message = firstSpaceIndex !== -1 ? this.#message.substring(firstSpaceIndex + 1) : '';
+		}
+
+		return recipient;
+	}
 	
+	isCommand() 
+	{
+		// Valid commands start with !		
+		return this.#commandPrefixes.includes(this.#message.charAt(0));
+	}
+
+	createCommand()
+	{
+		const command = {
+			commandName: "",
+			inputtext: "",
+			hasParameter: false
+		};
+
+		const spaceIndex = this.#message.indexOf(" ");
+
+		//used to check if the user send parameter
+		if(spaceIndex < 0)
+		{
+			command.commandName = this.#message.slice(1).toLowerCase();
+			command.hasParameter = false;
+		}
+		else
+		{
+			// The command name is the first substring one and remove the !:
+			command.commandName = this.#message.substring(1, spaceIndex).toLowerCase();
+			//The message that should be translated and remove the first space 
+			command.inputtext = this.#message.substring(spaceIndex +1);
+			command.hasParameter = true;					
+		}
+		return command;
+	}
 }
 
 module.exports = ChatMessage;

--- a/modules/chatmessage.js
+++ b/modules/chatmessage.js
@@ -1,0 +1,71 @@
+class ChatMessage {
+
+	#message;
+
+	constructor(message) {
+		this.#message = message;
+	}
+
+	getMessage() 
+	{
+		return this.#message;
+	}
+
+	cleanMessage(bannedWords) 
+	{
+		this.#removeURLs();
+		this.#removeBannedWords(bannedWords);
+		//remove all the extra spaces 
+		this.#message = this.#message.replace(/\s+/g, ' ').trim();
+	}
+
+	//remove banned words from the message
+	#removeBannedWords(bannedWords)
+	{
+		if (bannedWords.length > 0)
+		{
+			const bannedWordRegex = new RegExp(`\\b(${bannedWords.join('|')})\\b`, 'gi');
+			this.#message = this.#message.replace( bannedWordRegex, '');
+		}
+	}
+
+	//remove URLs from the message
+	#removeURLs()
+	{
+		const urlRegex = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[.\!\/\\w]*))?)/
+		this.#message = this.#message.replace(urlRegex, '');
+	}
+
+	//remove emotes from message, because they can mess up the translation. (Thanks to stefanjudis for this idea/example code on how to handle emotes)
+	//This also prevents the bot from trying to translate messages, that are filled with emotes only.
+	removeEmotes(emotes) 
+	{
+		// It also includes informations about the used emotes! Example emote [id, positions]: "425618": ["0-2"]
+		if(!emotes) 
+			return;
+
+		//array to save all emotes that needs to be deleted later.
+		var emotesToDelete=[];
+		//iterate of emotes to find all positions 
+		//using sequential loop to get all emotes.
+		for(const positions of Object.values(emotes))
+		{
+			const position = positions[0]; //We only need the first position for every emote, as we can relpace all emotes of this kind
+			const [start, end] = position.split("-");
+			//using match(/./gu) to get unicode emojis as one character. Twitch sees these at 1 character. JS String not.
+			//with this, I put all characters in an array, so the start and end positions are correct again.
+			emotesToDelete.push(this.#message.match(/./gu).slice(parseInt(start),parseInt(end)+1).join(''));		
+		}
+
+		//replace all emotes with an empty string
+		//using sequential loop to get all emotes. 
+		for(let emote of emotesToDelete){			
+			//NodeJS doesn't know replaceAll. So we need to use Regex. 	
+			//escape special character as some of them are used in emotes like ":)" or ":("	
+			this.#message = this.#message.replace(new RegExp(emote.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'), 'g'),'');
+		};
+	}
+	
+}
+
+module.exports = ChatMessage;

--- a/modules/chatmessage.js
+++ b/modules/chatmessage.js
@@ -94,8 +94,11 @@ class ChatMessage {
 		const command = {
 			commandName: "",
 			inputtext: "",
-			hasParameter: false
+			hasParameter: false,
+			recipient : null
 		};
+
+		command.recipient = this.getRecipient(); //get the recipient of the message if there is one
 
 		const spaceIndex = this.#message.indexOf(" ");
 
@@ -113,6 +116,7 @@ class ChatMessage {
 			command.inputtext = this.#message.substring(spaceIndex +1);
 			command.hasParameter = true;					
 		}
+		
 		return command;
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hanasuai",
-  "version": "1.6.3",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hanasuai",
-      "version": "1.6.3",
+      "version": "2.0.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "axios": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "name": "hanasuai",
   "description": "HanasuAI is a bot for translating text messages using the deepl API. The bot automatically detects the language of the message and translates it into the language specified with the command. \r HanasuAI also has an auto-translating function using the IBM Watson translator. The bot translates every message into Japanese or English, depending on what language was used in the message.",
-  "version": "1.6.3",
+  "version": "2.0.0",
   "main": "hanasuAI.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Restructured quite a bit.

spitted the main handleMessage function into smaller ones.
Cleaning the message is now done via a ChatMessage class.
The commands have been divided into functions that correspond to their role
Added feature for auto translating a specific user requested in #4 

Made the Translate function a lot smaller. Adding supported messages only requires to modify the language Mapping. 


BREAKING!!
- config.json now needs the languageMappings object
- channelconfig now needs an empty "autouser" array in each object